### PR TITLE
edit cp command flag for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Save files to the Packages/Sublime Text 3 Snippets directory, then relaunch Subl
 
 > cd SnipLime
 
-> Linux: sudo cp Python/ ~/.config/sublime-text-2/Packages/
+> Linux: sudo cp -r Python/ ~/.config/sublime-text-2/Packages/
 
 > Mac: sudo cp Python/ ~/Library/Application Support/Sublime-Text-3/Packages/
 


### PR DESCRIPTION
During use 
`sudo cp Python/ ~/.config/sublime-text-2/Packages/`
We got warning 

> cp: omitting directory 'Python/'

If we add flag `-r` 
 `sudo cp -r Python/ ~/.config/sublime-text-2/Packages/`
It's work correct.
